### PR TITLE
ci: Update GitHub Actions to latest releases and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    labels:
+      - "github-actions"
+    reviewers:
+      - "davidlange6"

--- a/.github/workflows/check_projects.yml
+++ b/.github/workflows/check_projects.yml
@@ -13,14 +13,14 @@ jobs:
         uses: actions/checkout@v4 # checkout the repository content
 
       - name: setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10" # install the python version needed
+          python-version: "3.x" # install the python version needed
 
       - name: install python packages
         run: |
           python -m pip install --upgrade pip
-          pip install pyyaml
+          python -m pip install --upgrade pyyaml
 
       - name: execute py script # run main.py
         run: "python ./_scripts/check_projects.py"

--- a/.github/workflows/submodule-update.yml
+++ b/.github/workflows/submodule-update.yml
@@ -26,7 +26,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       ####################################
       # Run the action against code base #

--- a/.github/workflows/yaml_checker.yml
+++ b/.github/workflows/yaml_checker.yml
@@ -10,6 +10,6 @@ jobs:
   validate-yaml:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Validate YAML file
         run: yamllint -c _scripts/yaml_lint.rules projects/.


### PR DESCRIPTION
* Update GitHub Actions to latest releases.
* Enable monthly grouped Dependabot GHA updates.